### PR TITLE
MNT:Nicer command line args. Standardizing the names

### DIFF
--- a/metadataservice/test/test_urls.py
+++ b/metadataservice/test/test_urls.py
@@ -35,4 +35,4 @@ class TestUrls:
 
     def teardown_class(self):
         mds_teardown()
-        print('Killed server after test')
+        print('\nKilled server after test')

--- a/metadataservice/test/utils.py
+++ b/metadataservice/test/utils.py
@@ -14,9 +14,9 @@ testing_config = dict(mongohost='localhost', mongoport=27017,
 def mds_setup():
     global proc
     f = os.path.dirname(os.path.realpath(__file__))
-    proc = Popen(["python", "../../startup.py", "--mongohost", testing_config["mongohost"],
-                  "--mongoport", str(testing_config['mongoport']), "--database", testing_config['database'],
-                  "--tzone", testing_config['tzone'], "--serviceport",
+    proc = Popen(["python", "../../startup.py", "--mongo-host", testing_config["mongohost"],
+                  "--mongo-port", str(testing_config['mongoport']), "--database", testing_config['database'],
+                  "--timezone", testing_config['tzone'], "--service-port",
            str(testing_config['serviceport'])], cwd=f)
     print('Started the server with configuration..:{}'.format(testing_config))
     ttime.sleep(5) # make sure the process is started

--- a/startup.py
+++ b/startup.py
@@ -23,16 +23,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--database', dest='database', type=str,
                         help='name of database to use')
-    parser.add_argument('--mongohost', dest='mongohost', type=str,
+    parser.add_argument('--mongo-host', dest='mongohost', type=str,
                         help='mongodb host to connect to')
     parser.add_argument('--timezone', dest='timezone', type=str,
                         help='Local timezone')
-    parser.add_argument('--mongoport', dest='mongoport', type=int,
+    parser.add_argument('--mongo-port', dest='mongoport', type=int,
                         help='mongodb port to connect')
-    parser.add_argument('--serviceport', dest='serviceport', type=int,
+    parser.add_argument('--service-port', dest='serviceport', type=int,
                         help='port to broadcast from')
-    parser.add_argument('--tzone', dest='timezone', type=str,
-                        help='timezone of the service env')
 
     args = parser.parse_args()
     if args.database is not None:


### PR DESCRIPTION
@hhslepicka Per our discussion, I am standardizing the command line args. This would obviously break the metadataclient tests on travis unless updated. I have another PR for metadataclient
See https://github.com/NSLS-II/metadataclient/pull/16